### PR TITLE
add support for facebook /v/ pattern

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -22,7 +22,7 @@ export const resolvers: Resolver[] = [
     name: 'facebook',
     prefix: 'fb',
     handlers: [j2, ytdl],
-    regex: /(?<!!)http(s)?:\/\/(www\.)?facebook.com\/((share\/r)|([a-z0-9._-]+\/videos)|reel)\/(?<id>[a-z0-9_-]+)/i,
+    regex: /(?<!!)http(s)?:\/\/(www\.)?facebook.com\/((share\/[rv])|([a-z0-9._-]+\/videos)|reel)\/(?<id>[a-z0-9_-]+)/i,
   },
   {
     name: 'facebook',


### PR DESCRIPTION
It seems Facebook can also have https://www.facebook.com/share/v/ so I added that to the resolver pattern.